### PR TITLE
Fix undefined http_status causing the game to crash

### DIFF
--- a/scripts/GoogAsyncHTTPEvent/GoogAsyncHTTPEvent.gml
+++ b/scripts/GoogAsyncHTTPEvent/GoogAsyncHTTPEvent.gml
@@ -7,13 +7,14 @@ function GoogAsyncHTTPEvent()
     var _id = async_load[? "id"];
     if (ds_map_exists(global.__GoogHTTPResponseMap, _id))
     {
+        if (async_load[? "status"] == 1) return;
         if (global.__GoogUsingAsyncEvent == undefined)
         {
             if (GOOG_DEBUG) __GoogTrace("Confirmed use of GoogAsyncHTTPEvent()");
             global.__GoogUsingAsyncEvent = true;
         }
         
-        if (floor(async_load[? "http_status"]/100) == 2)
+        if (async_load[? "http_status"] != undefined && floor(async_load[? "http_status"]/100) == 2)
         {
             if (GOOG_DEBUG)
             {


### PR DESCRIPTION
When the HTTP event returns a `status` of `1`, it indicates that the content is still being downloaded, according to the [GameMaker manual](https://manual.gamemaker.io/monthly/en/#t=The_Asset_Editors%2FObject_Properties%2FAsync_Events%2FHTTP.htm). Therefore the `http_status` variable can sometimes be undefined, which may cause the game to crash.